### PR TITLE
replaced size badge with deps and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 [![npm](https://img.shields.io/npm/v/bs-downshift.svg)](https://npmjs.org/bs-downshift)
 [![Issues](https://img.shields.io/github/issues/reasonml-community/bs-downshift.svg)](https://github.com/reasonml-community/bs-downshift/issues)
+[![Dependencies](https://img.shields.io/david/peer/reasonml-community/bs-downshift.svg)](https://github.com/reasonml-community/bs-downshift/blob/master/package.json)
+[![Issues](https://img.shields.io/github/issues/reasonml-community/bs-downshift.svg)](https://github.com/reasonml-community/bs-downshift/issues)
 [![Last Commit](https://img.shields.io/github/last-commit/reasonml-community/bs-downshift.svg)]()
-[![Size](https://img.shields.io/github/size/reasonml-community/bs-downshift/lib/js/src/Fetch.js.svg)]()
 
 ## Demo
 


### PR DESCRIPTION
The size badge isn't doing anything useful. Deps and issues are more informative, so I added those instead.

Also, `downshift` should probably be a dependency, not a peerDependency. The coupling between a set of bindings and the library they bind to is pretty tight, and it seems unlikely that you'll have other dependencies that themselves will depend on `downshift`.