### PR TITLE
Correctly pass index in getItemProps

### DIFF
--- a/examples/reason_downshift.re
+++ b/examples/reason_downshift.re
@@ -100,10 +100,8 @@ module BasicAutocomplete = {
                                         Downshift.toJsObj(
                                           Downshift.ControllerStateAndHelpers.getItemProps(
                                             t,
-                                            {
-                                              "item": Downshift.toAny(item),
-                                              "index": Some(0)
-                                            }
+                                            ~item=Downshift.toAny(item),
+                                            ()
                                           )
                                         ),
                                       [|ReasonReact.stringToElement(item)|]

--- a/src/Downshift.re
+++ b/src/Downshift.re
@@ -42,7 +42,7 @@ type rootPropsOptions = {. "refKey": string};
 
 type itemPropsOptions = {
   .
-  "index": option(int),
+  "index": Js.Nullable.t(int),
   "item": any
 };
 
@@ -62,7 +62,7 @@ module ControllerStateAndHelpers = {
   external getInputProps :
     (t, ~options: ReactDOMRe.reactDOMProps=?, unit) => any =
     "";
-  [@bs.send] external getItemProps : (t, itemPropsOptions) => any = "";
+  [@bs.send] external extGetItemProps : (t, itemPropsOptions) => any = "";
   [@bs.send]
   external itemPropsOptions : (t, ~options: itemPropsOptions) => any = "";
   /* Actions */
@@ -103,6 +103,10 @@ module ControllerStateAndHelpers = {
   [@bs.get] external inputValue : t => Js.Nullable.t(string) = "";
   [@bs.get] external isOpen : t => bool = "";
   [@bs.get] external selectedItem : t => item = "";
+  let getItemProps = (t, ~item: any, ~index=?, ()) : any => {
+    let itemPropsOpt = {"item": item, "index": Js.Nullable.from_opt(index)};
+    extGetItemProps(t, itemPropsOpt);
+  };
 };
 
 type stateChangeOptions = {

--- a/src/Downshift.rei
+++ b/src/Downshift.rei
@@ -34,7 +34,7 @@ type rootPropsOptions = {. "refKey": string};
 
 type itemPropsOptions = {
   .
-  "index": option(int),
+  "index": Js.Nullable.t(int),
   "item": any
 };
 
@@ -53,7 +53,7 @@ module ControllerStateAndHelpers: {
   external getInputProps :
     (t, ~options: ReactDOMRe.reactDOMProps=?, unit) => any =
     "";
-  [@bs.send] external getItemProps : (t, itemPropsOptions) => any = "";
+  [@bs.send] external extGetItemProps : (t, itemPropsOptions) => any = "";
   [@bs.send]
   external itemPropsOptions : (t, ~options: itemPropsOptions) => any = "";
   [@bs.send] external openMenu : (t, ~cb: cb=?, unit) => unit = "";
@@ -92,6 +92,7 @@ module ControllerStateAndHelpers: {
   [@bs.get] external inputValue : t => Js.Nullable.t(string) = "";
   [@bs.get] external isOpen : t => bool = "";
   [@bs.get] external selectedItem : t => item = "";
+  let getItemProps: (t, ~item: any, ~index: int=?, unit) => any;
 };
 
 type stateChangeOptions = {


### PR DESCRIPTION
Per discussion in #4, this changes the type of `itemPropsOptions` to pass `index` as a Nullable int, and then adds a new implementation for `getItemProps` that allows the user to optionally pass `index`.