### PR TITLE
fix: external extGetItemProps should bind to getItemProps

### DIFF
--- a/src/Downshift.re
+++ b/src/Downshift.re
@@ -55,7 +55,7 @@ module ControllerStateAndHelpers = {
   external getInputProps :
     (t, ~options: ReactDOMRe.reactDOMProps=?, unit) => any =
     "";
-  [@bs.send] external extGetItemProps : (t, itemPropsOptions) => any = "";
+  [@bs.send] external extGetItemProps : (t, itemPropsOptions) => any = "getItemProps";
   [@bs.send]
   external itemPropsOptions : (t, ~options: itemPropsOptions) => any = "";
   /* Actions */

--- a/src/Downshift.rei
+++ b/src/Downshift.rei
@@ -51,7 +51,7 @@ module ControllerStateAndHelpers: {
   external getInputProps :
     (t, ~options: ReactDOMRe.reactDOMProps=?, unit) => any =
     "";
-  [@bs.send] external extGetItemProps : (t, itemPropsOptions) => any = "";
+  [@bs.send] external extGetItemProps : (t, itemPropsOptions) => any = "getItemProps";
   [@bs.send]
   external itemPropsOptions : (t, ~options: itemPropsOptions) => any = "";
   [@bs.send] external openMenu : (t, ~cb: cb=?, unit) => unit = "";


### PR DESCRIPTION
Fixes #8.

As far as I can tell this has been broken since #5, unless I'm misunderstanding something.